### PR TITLE
Improve output

### DIFF
--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -23,49 +23,7 @@ param (
 # Measure initial count of certs
 $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
-# Download the new certs
-& certutil -v -syncWithWU -f -f "$sync_dir"
-If (!$?) {
-  Write-Host "syncWithWU failed!  Is your network connection down?"
-  exit 1
-}
-
-# Get the list of new certs
-$cert_files = Get-ChildItem "$sync_dir" -Filter "*.crt" | Sort-Object
-
-# Measure count of new certs
-$downloaded_cert_count = ($cert_files | Measure-Object -Line).Lines
-If (0 -eq $downloaded_cert_count) {
-  Write-Host "No certs downloaded from WU!  Is your network connection down?"
-  exit 1
-}
-
-# Import the new certs to the store
-:CERT foreach ($single_cert in $cert_files) {
-  Write-Host $single_cert.Name
-  foreach ( $TryNum in 1..10 ) {
-    & certutil -verify $single_cert.FullName | Set-Variable -Name verify_output
-    If (!$?) {
-      Write-Host "$verify_output"
-      Write-Host "Failed to import cert!  Retrying..."
-      Start-Sleep -seconds 5
-      continue
-    }
-    $cert_key_authroot = "HKLM:\SOFTWARE\Microsoft\SystemCertificates\AuthRoot\Certificates\" + $single_cert.Name.split(".")[0]
-    $cert_key_root = "HKLM:\SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\" + $single_cert.Name.split(".")[0]
-    If ( -not (Test-Path "$cert_key_authroot") -and -not (Test-Path "$cert_key_root") ) {
-      Write-Host "$verify_output"
-      Write-Host "Import had no effect!  Retrying..."
-      & certutil -store AuthRoot $single_cert.Name.split(".")[0]
-      Get-ChildItem -path "HKLM:\SOFTWARE\Microsoft\" -recurse -ErrorAction SilentlyContinue | Where-Object {$_.Name -like ("*" + $single_cert.Name)}
-      Start-Sleep -seconds 5
-      continue
-    }
-    # Success with this cert, move onto the next cert.
-    continue CERT
-  }
-  exit 1
-}
+& certutil -f -verifyCTL AuthRootWU
 
 # Measure final count of certs
 $final_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
@@ -73,6 +31,5 @@ $diff_cert_count = $final_cert_count - $initial_cert_count
 
 Write-Host "----- Results -----"
 Write-Host "----- Initial certs: $initial_cert_count -----"
-Write-Host "----- Downloaded certs: $downloaded_cert_count -----"
 Write-Host "----- Final certs: $final_cert_count -----"
 Write-Host "----- Diff (Final-Initial): $diff_cert_count -----"

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -56,6 +56,7 @@ If (0 -eq $downloaded_cert_count) {
     If ( -not (Test-Path "$cert_key_authroot") -and -not (Test-Path "$cert_key_root") ) {
       Write-Host "$verify_output"
       Write-Host "Import had no effect!  Retrying..."
+      & certutil -store AuthRoot $single_cert.Name.split(".")[0]
       Get-ChildItem -path "HKLM:\SOFTWARE\Microsoft\" -recurse -ErrorAction SilentlyContinue | Where-Object {$_.Name -like ("*" + $single_cert.Name)}
       Start-Sleep -seconds 5
       continue

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -23,19 +23,19 @@ param (
 # Measure initial count of certs
 $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
-Write-Host "Verifying cached registry AuthRootSTL"
+Write-Host "----- Verifying cached registry AuthRootSTL -----"
 & certutil -verifyCTL AuthRoot
 $stage1_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
-Write-Host "Verifying updated registry AuthRootSTL"
+Write-Host "----- Verifying updated registry AuthRootSTL -----"
 & certutil -f -verifyCTL AuthRoot
 $stage2_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
-Write-Host "Verifying CAB AuthRootSTL"
+Write-Host "----- Verifying CAB AuthRootSTL -----"
 & certutil -verifyCTL AuthRootWU
 $stage3_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
-Write-Host "Verifying Windows Update AuthRootSTL"
+Write-Host "----- Verifying Windows Update AuthRootSTL -----"
 & certutil -f -verifyCTL AuthRootWU
 
 # Measure final count of certs

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -23,20 +23,20 @@ param (
 # Measure initial count of certs
 $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
+Write-Host "----- Verifying Windows Update AuthRootSTL -----"
+& certutil -f -verifyCTL AuthRootWU
+$stage1_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+
 Write-Host "----- Verifying cached registry AuthRootSTL -----"
 & certutil -verifyCTL AuthRoot
-$stage1_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+$stage2_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
 Write-Host "----- Verifying updated registry AuthRootSTL -----"
 & certutil -f -verifyCTL AuthRoot
-$stage2_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+$stage3_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
 Write-Host "----- Verifying CAB AuthRootSTL -----"
 & certutil -verifyCTL AuthRootWU
-$stage3_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
-
-Write-Host "----- Verifying Windows Update AuthRootSTL -----"
-& certutil -f -verifyCTL AuthRootWU
 
 # Measure final count of certs
 $final_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -25,6 +25,18 @@ $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== 
 
 Write-Host "Verifying cached registry AuthRootSTL"
 & certutil -verifyCTL AuthRoot
+$stage1_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+
+Write-Host "Verifying updated registry AuthRootSTL"
+& certutil -f -verifyCTL AuthRoot
+$stage2_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+
+Write-Host "Verifying CAB AuthRootSTL"
+& certutil -verifyCTL AuthRootWU
+$stage3_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+
+Write-Host "Verifying Windows Update AuthRootSTL"
+& certutil -f -verifyCTL AuthRootWU
 
 # Measure final count of certs
 $final_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
@@ -32,5 +44,8 @@ $diff_cert_count = $final_cert_count - $initial_cert_count
 
 Write-Host "----- Results -----"
 Write-Host "----- Initial certs: $initial_cert_count -----"
+Write-Host "----- Stage1 certs: $stage1_cert_count -----"
+Write-Host "----- Stage2 certs: $stage2_cert_count -----"
+Write-Host "----- Stage3 certs: $stage3_cert_count -----"
 Write-Host "----- Final certs: $final_cert_count -----"
 Write-Host "----- Diff (Final-Initial): $diff_cert_count -----"

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -34,7 +34,8 @@ $downloaded_cert_count = ($cert_files | Measure-Object -Line).Lines
 
 # Import the new certs to the store
 foreach ($single_cert in $cert_files) {
-  & certutil -verify $single_cert.FullName
+  Write-Host $single_cert.Name
+  & certutil -verify $single_cert.FullName | Out-Null
 }
 
 # Measure final count of certs

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -44,8 +44,9 @@ If (0 -eq $downloaded_cert_count) {
 :CERT foreach ($single_cert in $cert_files) {
   Write-Host $single_cert.Name
   foreach ( $TryNum in 1..10 ) {
-    & certutil -verify $single_cert.FullName | Out-Null
+    & certutil -verify $single_cert.FullName | Set-Variable -Name verify_output
     If (!$?) {
+      Write-Host "$verify_output"
       Write-Host "Failed to import cert!  Retrying..."
       Start-Sleep -seconds 5
       continue
@@ -53,6 +54,7 @@ If (0 -eq $downloaded_cert_count) {
     $cert_key_authroot = "HKLM:\SOFTWARE\Microsoft\SystemCertificates\AuthRoot\Certificates\" + $single_cert.Name.split(".")[0]
     $cert_key_root = "HKLM:\SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\" + $single_cert.Name.split(".")[0]
     If ( -not (Test-Path "$cert_key_authroot") -and -not (Test-Path "$cert_key_root") ) {
+      Write-Host "$verify_output"
       Write-Host "Import had no effect!  Retrying..."
       Start-Sleep -seconds 5
       continue

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -35,6 +35,10 @@ $cert_files = Get-ChildItem "$sync_dir" -Filter "*.crt" | Sort-Object
 
 # Measure count of new certs
 $downloaded_cert_count = ($cert_files | Measure-Object -Line).Lines
+If (0 -eq $downloaded_cert_count) {
+  Write-Host "No certs downloaded from WU!  Is your network connection down?"
+  exit 1
+}
 
 # Import the new certs to the store
 foreach ($single_cert in $cert_files) {

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -21,7 +21,7 @@ param (
 )
 
 # Measure initial count of certs
-$initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+$initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
 # Download the new certs
 & certutil -v -syncWithWU -f -f "$sync_dir"
@@ -57,7 +57,7 @@ foreach ($single_cert in $cert_files) {
 }
 
 # Measure final count of certs
-$final_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
+$final_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 $diff_cert_count = $final_cert_count - $initial_cert_count
 
 Write-Host "----- Results -----"

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -25,6 +25,10 @@ $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== 
 
 # Download the new certs
 & certutil -v -syncWithWU -f -f "$sync_dir"
+If (!$?) {
+  Write-Host "syncWithWU failed!  Is your network connection down?"
+  exit 1
+}
 
 # Get the list of new certs
 $cert_files = Get-ChildItem "$sync_dir" -Filter "*.crt" | Sort-Object

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -44,6 +44,10 @@ If (0 -eq $downloaded_cert_count) {
 foreach ($single_cert in $cert_files) {
   Write-Host $single_cert.Name
   & certutil -verify $single_cert.FullName | Out-Null
+  If (!$?) {
+    Write-Host "Failed to import cert!"
+    exit 1
+  }
 }
 
 # Measure final count of certs

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -23,7 +23,8 @@ param (
 # Measure initial count of certs
 $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines
 
-& certutil -f -verifyCTL AuthRootWU
+Write-Host "Verifying cached registry AuthRootSTL"
+& certutil -verifyCTL AuthRoot
 
 # Measure final count of certs
 $final_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines + (& certutil -store Root | Select-String -Pattern "=== Certificate \d+ ===" | Measure-Object -Line).Lines

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -48,6 +48,12 @@ foreach ($single_cert in $cert_files) {
     Write-Host "Failed to import cert!"
     exit 1
   }
+  $cert_key_authroot = "HKLM:\SOFTWARE\Microsoft\SystemCertificates\AuthRoot\Certificates\" + $single_cert.Name.split(".")[0]
+  $cert_key_root = "HKLM:\SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\" + $single_cert.Name.split(".")[0]
+  If ( -not (Test-Path "$cert_key_authroot") -and -not (Test-Path "$cert_key_root") ) {
+    Write-Host "Import had no effect!"
+    exit 1
+  }
 }
 
 # Measure final count of certs

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -27,7 +27,7 @@ $initial_cert_count = (& certutil -store AuthRoot | Select-String -Pattern "=== 
 & certutil -v -syncWithWU -f -f "$sync_dir"
 
 # Get the list of new certs
-$cert_files = Get-ChildItem "$sync_dir" -Filter "*.crt"
+$cert_files = Get-ChildItem "$sync_dir" -Filter "*.crt" | Sort-Object
 
 # Measure count of new certs
 $downloaded_cert_count = ($cert_files | Measure-Object -Line).Lines

--- a/ctlpop.ps1
+++ b/ctlpop.ps1
@@ -56,6 +56,7 @@ If (0 -eq $downloaded_cert_count) {
     If ( -not (Test-Path "$cert_key_authroot") -and -not (Test-Path "$cert_key_root") ) {
       Write-Host "$verify_output"
       Write-Host "Import had no effect!  Retrying..."
+      Get-ChildItem -path "HKLM:\SOFTWARE\Microsoft\" -recurse -ErrorAction SilentlyContinue | Where-Object {$_.Name -like ("*" + $single_cert.Name)}
       Start-Sleep -seconds 5
       continue
     }

--- a/testdata/travis.bash
+++ b/testdata/travis.bash
@@ -3,7 +3,7 @@ set -euxo pipefail
 shopt -s nullglob globstar
 
 # Wipe the authroot.stl so that it gets refreshed.
-powershell -command 'Remove-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\SystemCertificates\AuthRoot\AutoUpdate -Name LastSyncTime'
+#powershell -command 'Remove-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\SystemCertificates\AuthRoot\AutoUpdate -Name LastSyncTime'
 
 mkdir sync1
 powershell -ExecutionPolicy Unrestricted -File "ctlpop.ps1" "-sync_dir" "sync1" | tee run1.log

--- a/testdata/travis.bash
+++ b/testdata/travis.bash
@@ -2,6 +2,9 @@
 set -euxo pipefail
 shopt -s nullglob globstar
 
+# Wipe the authroot.stl so that it gets refreshed.
+powershell -command 'Remove-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\SystemCertificates\AuthRoot\AutoUpdate -Name LastSyncTime'
+
 mkdir sync1
 powershell -ExecutionPolicy Unrestricted -File "ctlpop.ps1" "-sync_dir" "sync1" | tee run1.log
 


### PR DESCRIPTION
* Suppress noisy output of `certutil -verify`
* Sort certificates by SHA1 hash (makes it easier to monitor progress)
* Detect failures and return an exit code accordingly
* Check `Root` logical store for statistics in addition to `AuthRoot`